### PR TITLE
[CSS-11] Events grid

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import LoginPage from "./Pages/login-page";
 import Background from "./components/Background";
-
+import EventsGrid from "./components/EventsGrid";
 
 // Create a Layout component for the main content
 const Layout = () => {
@@ -10,9 +10,7 @@ const Layout = () => {
     <>
       <Background />
       <Navbar />
-      <div className="bg-background-primary flex h-[2000px] justify-center overflow-hidden">
-        [content goes here]
-      </div>
+      <EventsGrid />
     </>
   );
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,14 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Navbar from "./components/Navbar";
 import LoginPage from "./Pages/login-page";
+import Background from "./components/Background";
+
 
 // Create a Layout component for the main content
 const Layout = () => {
   return (
     <>
+      <Background />
       <Navbar />
       <div className="bg-background-primary flex h-[2000px] justify-center overflow-hidden">
         [content goes here]

--- a/frontend/src/Pages/login-page.tsx
+++ b/frontend/src/Pages/login-page.tsx
@@ -1,26 +1,29 @@
-import backgroundSvg from '../assets/royal-botanic-gardens-sydney-australia 1.svg';
+import backgroundSvg from "../assets/royal-botanic-gardens-sydney-australia 1.svg";
 
 export default function LoginPage() {
-    return (
-        <div 
-            className="min-h-screen w-full bg-cover bg-center flex justify-center items-center"
-            style={{ backgroundImage: `url(${backgroundSvg})`}}
-        >
-            <div className="bg-white p-8 w-[400px] h-[500px] rounded-lg shadow-lg flex flex-col">
-                <div className="pb-6 text-2xl font-bold text-center">LOGO GOES HERE</div>
-                <div className="pb-2 text-3xl font-bold text-gray-800">WELCOME!</div>
-                <div className="pb-10 text-3xl font-bold text-gray-800">WHAT'S YOUR EMAIL?</div>
-                <input type="text"
-                    placeholder="Email"
-                    className="mb-8 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                /> 
-                <button className="bg-blue-500 text-white py-2 px-4 rounded-md hover:bg-blue-600 transition-colors">
-                    Continue
-                </button>
-                <div>
-                    TODO: AUTHENTICATE USING GMAIL CONTAINER
-                </div>
-            </div>
+  return (
+    <div
+      className="flex min-h-screen w-full items-center justify-center bg-cover bg-center"
+      style={{ backgroundImage: `url(${backgroundSvg})` }}
+    >
+      <div className="flex h-[500px] w-[400px] flex-col rounded-lg bg-white p-8 shadow-lg">
+        <div className="pb-6 text-center text-2xl font-bold">
+          LOGO GOES HERE
         </div>
-    );
+        <div className="pb-2 text-3xl font-bold text-gray-800">WELCOME!</div>
+        <div className="pb-10 text-3xl font-bold text-gray-800">
+          WHAT'S YOUR EMAIL?
+        </div>
+        <input
+          type="text"
+          placeholder="Email"
+          className="mb-8 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 focus:outline-none sm:text-sm"
+        />
+        <button className="rounded-md bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600">
+          Continue
+        </button>
+        <div>TODO: AUTHENTICATE USING GMAIL CONTAINER</div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/Background.tsx
+++ b/frontend/src/components/Background.tsx
@@ -1,8 +1,7 @@
 const Background = () => {
-
   return (
-    <div className="fixed inset-0 w-screen h-screen bg-background-primary -z-50"></div>
+    <div className="bg-background-primary fixed inset-0 -z-50 h-screen w-screen"></div>
   );
 };
 
-export default Background
+export default Background;

--- a/frontend/src/components/Background.tsx
+++ b/frontend/src/components/Background.tsx
@@ -1,0 +1,8 @@
+const Background = () => {
+
+  return (
+    <div className="fixed inset-0 w-screen h-screen bg-background-primary -z-50"></div>
+  );
+};
+
+export default Background

--- a/frontend/src/components/EventsGrid.tsx
+++ b/frontend/src/components/EventsGrid.tsx
@@ -1,0 +1,7 @@
+const EventsGrid = () => {
+    return (
+        <></>
+    );
+};
+
+export default EventsGrid

--- a/frontend/src/components/EventsGrid.tsx
+++ b/frontend/src/components/EventsGrid.tsx
@@ -1,7 +1,85 @@
+import type { Event } from "../data/EventsData";
+import { popularEvents, weekendEvents } from "../data/EventsData";
+
+
 const EventsGrid = () => {
+  interface EventCardProps {
+    event: Event;
+  }
+
+  // Seperate function for creating each individual event card
+  const EventCard = ({ event }: EventCardProps) => {
+
+    // Adds status tag
+    const GetStatus = (status: string) => {
+      if (status === "Nearly full") {
+        return "bg-orange-100 text-orange-800";
+      } else if (status === "Full") {
+        return "bg-red-100 text-red-800";
+      } else if (status === "Popular") {
+        return "bg-blue-100 text-blue-800";
+      }
+    };
+
     return (
-        <></>
+      <div className="w-85 flex-shrink-0 cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm hover:bg-button-background-hover hover:scale-102 duration-400">
+        <div className="relative">
+          <img
+            src={event.image}
+            alt={event.title}
+            className="h-48 w-full object-cover"
+          />
+          {event.status && (
+            <div
+              className={`absolute top-3 left-3 rounded px-2 py-1 text-xs font-medium ${GetStatus(
+                event.status,
+              )}`}
+            >
+              {event.status}
+            </div>
+          )}
+        </div>
+        <div className="p-4">
+          <h3 className="mb-2 line-clamp-2 text-sm font-semibold text-gray-900">
+            {event.title}
+          </h3>
+          <p className="mb-1 text-sm text-gray-600 line-clamp-1">{event.date}</p>
+          <p className="mb-2 text-sm text-gray-600 line-clamp-1">{event.venue}</p>
+          <p className="text-sm font-medium text-gray-900 line-clamp-1">{event.price}</p>
+        </div>
+      </div>
     );
+  };
+
+  interface EventShowcaseProps {
+    title: string;
+    events: Event[];
+  }
+
+  // Main body that houses all event cards
+  // Calls individual event card function for every item in events array
+  const EventShowcase = ({ title, events }: EventShowcaseProps) => {
+    return (
+      <div className="mb-12">
+        <h2 className="mb-6 text-2xl font-bold text-gray-900">{title}</h2>
+
+        {/* Independant scaling */}
+        <div className="flex gap-4 overflow-x-auto pb-2 items-start">
+          {events.map((event) => (
+            // Note, key prop is not passed, by it used by react for more efficient rendering i think?
+            <EventCard key={event.id} event={event} />
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="mx-auto min-h-screen max-w-7xl bg-background-primary px-6 py-8">
+      <EventShowcase title="Popular events" events={popularEvents} />
+      <EventShowcase title="This weekend" events={weekendEvents} />
+    </div>
+  );
 };
 
-export default EventsGrid
+export default EventsGrid;

--- a/frontend/src/components/EventsGrid.tsx
+++ b/frontend/src/components/EventsGrid.tsx
@@ -1,7 +1,6 @@
 import type { Event } from "../data/EventsData";
 import { popularEvents, weekendEvents } from "../data/EventsData";
 
-
 const EventsGrid = () => {
   interface EventCardProps {
     event: Event;
@@ -9,7 +8,6 @@ const EventsGrid = () => {
 
   // Seperate function for creating each individual event card
   const EventCard = ({ event }: EventCardProps) => {
-
     // Adds status tag
     const GetStatus = (status: string) => {
       if (status === "Nearly full") {
@@ -22,7 +20,7 @@ const EventsGrid = () => {
     };
 
     return (
-      <div className="w-85 flex-shrink-0 cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm hover:bg-button-background-hover hover:scale-102 duration-400">
+      <div className="hover:bg-button-background-hover w-85 flex-shrink-0 cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm duration-400 hover:scale-102">
         <div className="relative">
           <img
             src={event.image}
@@ -43,9 +41,15 @@ const EventsGrid = () => {
           <h3 className="mb-2 line-clamp-2 text-sm font-semibold text-gray-900">
             {event.title}
           </h3>
-          <p className="mb-1 text-sm text-gray-600 line-clamp-1">{event.date}</p>
-          <p className="mb-2 text-sm text-gray-600 line-clamp-1">{event.venue}</p>
-          <p className="text-sm font-medium text-gray-900 line-clamp-1">{event.price}</p>
+          <p className="mb-1 line-clamp-1 text-sm text-gray-600">
+            {event.date}
+          </p>
+          <p className="mb-2 line-clamp-1 text-sm text-gray-600">
+            {event.venue}
+          </p>
+          <p className="line-clamp-1 text-sm font-medium text-gray-900">
+            {event.price}
+          </p>
         </div>
       </div>
     );
@@ -64,7 +68,7 @@ const EventsGrid = () => {
         <h2 className="mb-6 text-2xl font-bold text-gray-900">{title}</h2>
 
         {/* Independant scaling */}
-        <div className="flex gap-4 overflow-x-auto pb-2 items-start">
+        <div className="flex items-start gap-4 overflow-x-auto pb-2">
           {events.map((event) => (
             // Note, key prop is not passed, by it used by react for more efficient rendering i think?
             <EventCard key={event.id} event={event} />
@@ -75,7 +79,7 @@ const EventsGrid = () => {
   };
 
   return (
-    <div className="mx-auto min-h-screen max-w-7xl bg-background-primary px-6 py-8">
+    <div className="bg-background-primary mx-auto min-h-screen max-w-7xl px-6 py-8">
       <EventShowcase title="Popular events" events={popularEvents} />
       <EventShowcase title="This weekend" events={weekendEvents} />
     </div>

--- a/frontend/src/components/EventsGrid.tsx
+++ b/frontend/src/components/EventsGrid.tsx
@@ -1,83 +1,85 @@
 import type { Event } from "../data/EventsData";
 import { popularEvents, weekendEvents } from "../data/EventsData";
+import { memo } from "react";
+
+// Adds status tag
+const GetStatus = (status: string) => {
+  if (status === "Nearly full") {
+    return "bg-orange-100 text-orange-800";
+  } else if (status === "Full") {
+    return "bg-red-100 text-red-800";
+  } else if (status === "Popular") {
+    return "bg-blue-100 text-blue-800";
+  }
+  return "";
+};
+
+interface EventCardProps {
+  event: Event;
+}
+
+// Seperate function for creating each individual event card
+const EventCard = memo(({ event }: EventCardProps) => {
+  return (
+    <div className="hover:bg-button-background-hover w-85 flex-shrink-0 cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-transform duration-400 hover:scale-102 transform-gpu">
+      <div className="relative">
+        <img
+          src={event.image}
+          alt={event.title}
+          className="h-48 w-full object-cover"
+        />
+        {event.status && (
+          <div
+            className={`absolute top-3 left-3 rounded px-2 py-1 text-xs font-medium ${GetStatus(
+              event.status,
+            )}`}
+          >
+            {event.status}
+          </div>
+        )}
+      </div>
+      <div className="p-4">
+        <h3 className="mb-2 line-clamp-2 text-sm font-semibold text-gray-900">
+          {event.title}
+        </h3>
+        <p className="mb-1 line-clamp-1 text-sm text-gray-600">
+          {event.date}
+        </p>
+        <p className="mb-2 line-clamp-1 text-sm text-gray-600">
+          {event.venue}
+        </p>
+        <p className="line-clamp-1 text-sm font-medium text-gray-900">
+          {event.price}
+        </p>
+      </div>
+    </div>
+  );
+});
+
+interface EventShowcaseProps {
+  title: string;
+  events: Event[];
+}
+
+// Main body that houses all event cards
+// Calls individual event card function for every item in events array
+const EventShowcase = memo(({ title, events }: EventShowcaseProps) => {
+  return (
+    <div className="mb-12">
+      <h2 className="mb-6 text-2xl font-bold text-gray-900">{title}</h2>
+
+      {/* Independant scaling */}
+      <div className="flex items-start gap-4 overflow-x-auto pb-2">
+        {events.map((event) => (
+          // Note, key prop is not passed, by it used by react for more efficient rendering i think?
+          <EventCard key={event.id} event={event} />
+        ))}
+      </div>
+    </div>
+  );
+});
 
 const EventsGrid = () => {
-  interface EventCardProps {
-    event: Event;
-  }
-
-  // Seperate function for creating each individual event card
-  const EventCard = ({ event }: EventCardProps) => {
-    // Adds status tag
-    const GetStatus = (status: string) => {
-      if (status === "Nearly full") {
-        return "bg-orange-100 text-orange-800";
-      } else if (status === "Full") {
-        return "bg-red-100 text-red-800";
-      } else if (status === "Popular") {
-        return "bg-blue-100 text-blue-800";
-      }
-    };
-
-    return (
-      <div className="hover:bg-button-background-hover w-85 flex-shrink-0 cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm duration-400 hover:scale-102">
-        <div className="relative">
-          <img
-            src={event.image}
-            alt={event.title}
-            className="h-48 w-full object-cover"
-          />
-          {event.status && (
-            <div
-              className={`absolute top-3 left-3 rounded px-2 py-1 text-xs font-medium ${GetStatus(
-                event.status,
-              )}`}
-            >
-              {event.status}
-            </div>
-          )}
-        </div>
-        <div className="p-4">
-          <h3 className="mb-2 line-clamp-2 text-sm font-semibold text-gray-900">
-            {event.title}
-          </h3>
-          <p className="mb-1 line-clamp-1 text-sm text-gray-600">
-            {event.date}
-          </p>
-          <p className="mb-2 line-clamp-1 text-sm text-gray-600">
-            {event.venue}
-          </p>
-          <p className="line-clamp-1 text-sm font-medium text-gray-900">
-            {event.price}
-          </p>
-        </div>
-      </div>
-    );
-  };
-
-  interface EventShowcaseProps {
-    title: string;
-    events: Event[];
-  }
-
-  // Main body that houses all event cards
-  // Calls individual event card function for every item in events array
-  const EventShowcase = ({ title, events }: EventShowcaseProps) => {
-    return (
-      <div className="mb-12">
-        <h2 className="mb-6 text-2xl font-bold text-gray-900">{title}</h2>
-
-        {/* Independant scaling */}
-        <div className="flex items-start gap-4 overflow-x-auto pb-2">
-          {events.map((event) => (
-            // Note, key prop is not passed, by it used by react for more efficient rendering i think?
-            <EventCard key={event.id} event={event} />
-          ))}
-        </div>
-      </div>
-    );
-  };
-
   return (
     <div className="bg-background-primary mx-auto min-h-screen max-w-7xl px-6 py-8">
       <EventShowcase title="Popular events" events={popularEvents} />

--- a/frontend/src/components/Hamburger.tsx
+++ b/frontend/src/components/Hamburger.tsx
@@ -42,7 +42,7 @@ const Hamburger = () => {
             />
           </div>
 
-          <div className="flex justify-center gap-2">  
+          <div className="flex justify-center gap-2">
             <button className="bg-secondary-button-background hover:text-button-text-hover hover:bg-button-background-hover flex cursor-pointer items-center gap-2 rounded-3xl px-3 py-2 text-white transition-colors">
               <KeyRound size={16} />
               User login

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -164,11 +164,11 @@ const Navbar = () => {
             {/* Dropdown Menu */}
             {loginIsClicked && (
               <div className="absolute right-0 z-50 mt-2 w-48 rounded-xl border border-neutral-200 bg-white py-2 shadow-lg">
-                <button className="hover:bg-button-background-hover flex w-full items-center gap-3 px-4 py-2 text-left text-sm text-button-text transition-colors">
+                <button className="hover:bg-button-background-hover text-button-text flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors">
                   <User size={16} className="text-neutral-400" />
                   Users
                 </button>
-                <button className="hover:bg-button-background-hover flex w-full items-center gap-3 px-4 py-2 text-left text-sm text-button-text transition-colors">
+                <button className="hover:bg-button-background-hover text-button-text flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors">
                   <Building2 size={16} className="text-neutral-400" />
                   Hosts
                 </button>

--- a/frontend/src/data/EventsData.ts
+++ b/frontend/src/data/EventsData.ts
@@ -1,0 +1,108 @@
+import theking from "../assets/maxresdefault.svg";
+
+export interface Event {
+  id: number;
+  title: string;
+  date: string;
+  venue: string;
+  price: string;
+  status: string;
+  image: any;
+}
+
+export const popularEvents: Event[] = [
+  {
+    id: 1,
+    title: "LeOblock",
+    date: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "Full",
+    image: theking,
+  },
+  {
+    id: 2,
+    title: "LeOblock",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "Nearly full",
+    image: theking,
+  },
+  {
+    id: 3,
+    title:
+      "LeOblock | LeOblock | LeOblock | LeOblock | LeOblock | LeOblock | LeOblock | LeOblock | LeOblock",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "",
+    image: theking,
+  },
+  {
+    id: 4,
+    title: "LeSpeed Date | Courtside lakers",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "Popular",
+    image: theking,
+  },
+  {
+    id: 5,
+    title: "LeSpeed Date | Courtside lakers",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "",
+    image: theking,
+  },
+];
+
+export const weekendEvents: Event[] = [
+  {
+    id: 1,
+    title: "LeSpeed Date | Courtside lakers",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "Full",
+    image: theking,
+  },
+  {
+    id: 2,
+    title: "LeSpeed Date | Courtside lakers",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "Nearly full",
+    image: theking,
+  },
+  {
+    id: 3,
+    title: "LeSpeed Date | Courtside lakers",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "",
+    image: theking,
+  },
+  {
+    id: 4,
+    title: "LeSpeed Date | Courtside lakers",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "Popular",
+    image: theking,
+  },
+  {
+    id: 5,
+    title: "LeSpeed Date | Courtside lakers",
+    date: "Tuesday at 7:00 PM",
+    venue: "Courtside Lakers",
+    price: "From $1",
+    status: "",
+    image: theking,
+  },
+];


### PR DESCRIPTION
- Split functionality and data storage (event info) into two seperate files
- Added line clamping to truncate long sentences
- Added a background component that covers entire page (currently default but can be modified)
- Kingvon reunion
- Fixed issue with lag (constant rerendering)
 - Reorganised function structure
 - Added memoisation for future filtering cases
 - Shifted hover effects load to gpu instead
